### PR TITLE
Add automatic cleanup of closed and undefined subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add automatic cleanup of closed and undefined subscriptions to prevent memory leaks. The garbage collector runs every 10 seconds and removes closed or invalid subscriptions from the tracked array, logging warnings for undefined entries.
+
 ## [2.2.0]
 ### Added
 - Simple profiler options for saga time usage

--- a/src/createModelSaga.ts
+++ b/src/createModelSaga.ts
@@ -104,6 +104,14 @@ function startGarbageCollector(subscriptions: Subscription[]) {
 	const intervalHandler = setInterval(
 		() => {
 			for (let index in subscriptions) {
+				const subscription = subscriptions[index];
+
+				if (!subscription) {
+					console.warn(`Found undefined subscription at index ${index}, removing it`);
+					subscriptions.splice(parseInt(index), 1);
+					continue;
+				}
+
 				if (subscriptions[index].closed) {
 					subscriptions.splice(parseInt(index), 1);
 				}


### PR DESCRIPTION
Add automatic cleanup of closed and undefined subscriptions to prevent memory leaks

The garbage collector runs every 10 seconds and removes closed or invalid subscriptions from the tracked array, logging warnings for undefined entries.